### PR TITLE
chore: skip full CI suite for dependabot PRs

### DIFF
--- a/.github/workflows/code-quality-review.yml
+++ b/.github/workflows/code-quality-review.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   quality-review:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]' || github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/template-smoke-tests.yml
+++ b/.github/workflows/template-smoke-tests.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   smoke-test:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]' || github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Add `if: github.actor != 'dependabot[bot]' || github.event_name != 'pull_request'` to `smoke-test` job in `template-smoke-tests.yml`
- Add the same condition to `quality-review` job in `code-quality-review.yml`
- `quality.yml` already had this condition on `detect-maturity` -- no changes needed there
- Dependabot PRs will skip these expensive jobs and auto-merge faster, saving CI minutes

## Test plan
- [ ] Verify non-dependabot PRs still run smoke tests and quality review
- [ ] Verify push-to-main still triggers all jobs
- [ ] Confirm dependabot PRs skip the guarded jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)