### PR TITLE
chore: PR-only CI triggers (remove redundant push)

### DIFF
--- a/.github/workflows/code-quality-review.yml
+++ b/.github/workflows/code-quality-review.yml
@@ -1,8 +1,6 @@
 name: Code Quality & Review
 
 on:
-  push:
-    branches: [ master, main ]
   pull_request:
   workflow_dispatch:  # Allow manual triggering
 

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -10,7 +10,7 @@ name: Quality Checks
 # This avoids redundant work and reduces CI costs
 
 on:
-  push:
+  push: # Kept: catches direct pushes and scheduled scans
     branches: [main, master, develop]
     paths-ignore:
       - '**.md'


### PR DESCRIPTION
## Summary
- Removed `push` trigger from `code-quality-review.yml` — had both `push` and `pull_request` on same branches
- Kept `push` trigger on `quality.yml` (has `schedule` trigger too) with explanatory comment: catches direct pushes and scheduled scans

## Why
When a workflow triggers on both `push` and `pull_request` to the same branches, every PR merge fires CI twice — once for the push to main and once for the PR event. Removing the redundant `push` trigger halves CI minutes on merges.

## Test plan
- [ ] Verify `code-quality-review.yml` still runs on PRs
- [ ] Verify `quality.yml` still runs on push to main and monthly schedule
- [ ] Verify no double runs on merge

Generated with [Claude Code](https://claude.com/claude-code)