### PR TITLE
chore: skip template smoke tests for Dependabot PRs

### DIFF
--- a/.github/workflows/template-smoke-tests.yml
+++ b/.github/workflows/template-smoke-tests.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   smoke-test:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- Add `if: github.actor != 'dependabot[bot]'` to `smoke-test` job in `template-smoke-tests.yml`
- Prevents the 4-template matrix (smoke + coverage + accessibility = ~12 jobs) from running on every Dependabot PR
- These jobs were the source of the CI failures seen on dep bump PRs and were burning the most minutes

## Before / After
- **Before**: Every Dependabot PR triggered 4 smoke-test + 3 coverage + 2 accessibility jobs (~20+ min, always failing anyway)
- **After**: Dependabot PRs skip entirely; the workflow only runs on human-authored PRs

## Notes
- `dependabot.yml` is already on monthly schedule with full grouping
- This only affects PR-triggered runs, not manual `workflow_dispatch` triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)