### PR TITLE
fix: use safe same-origin upgrade links

### DIFF
--- a/templates/monetization/billing/dashboard.html
+++ b/templates/monetization/billing/dashboard.html
@@ -22,8 +22,8 @@
     <div class="card">
       <h3>Current Plan</h3>
       <p class="muted">Free · Upgrade to unlock {{PRO_FEATURE_1}}, {{PRO_FEATURE_2}}, {{PRO_FEATURE_3}}</p>
-      <button onclick="window.location.href='{{UPGRADE_URL}}'">Upgrade to Pro (${{PRO_PRICE}}/mo)</button>
-      <button style="margin-left:8px; background:#1f2638; color:#e8ecf4; border:1px solid #2e3550;" onclick="window.location.href='{{ENTERPRISE_UPGRADE_URL}}'">Talk to Sales</button>
+      <button onclick="window.location.href='/upgrade'">Upgrade to Pro (${{PRO_PRICE}}/mo)</button>
+      <button style="margin-left:8px; background:#1f2638; color:#e8ecf4; border:1px solid #2e3550;" onclick="window.location.href='/enterprise'">Talk to Sales</button>
     </div>
 
     <div class="card">

--- a/templates/monetization/marketing/landing-page.html
+++ b/templates/monetization/marketing/landing-page.html
@@ -72,8 +72,8 @@
           <div class="feature">⚡ Ready-to-ship legal + billing pages</div>
         </div>
         <div class="cta">
-          <a class="btn btn-primary" href="{{UPGRADE_URL}}" aria-label="Upgrade to Pro for ${{PRO_PRICE}} per month">Start Pro — ${{PRO_PRICE}}/mo</a>
-          <a class="btn btn-ghost" href="{{ENTERPRISE_UPGRADE_URL}}" aria-label="View Enterprise plan for ${{ENTERPRISE_PRICE}} per month">Enterprise — ${{ENTERPRISE_PRICE}}/mo</a>
+          <a class="btn btn-primary" href="/upgrade" aria-label="Upgrade to Pro for ${{PRO_PRICE}} per month">Start Pro — ${{PRO_PRICE}}/mo</a>
+          <a class="btn btn-ghost" href="/enterprise" aria-label="View Enterprise plan for ${{ENTERPRISE_PRICE}} per month">Enterprise — ${{ENTERPRISE_PRICE}}/mo</a>
         </div>
       </div>
       <div class="card" aria-label="Live preview of license commands">

--- a/tests/integration/monetization-templates.test.mjs
+++ b/tests/integration/monetization-templates.test.mjs
@@ -114,6 +114,24 @@ describe('Monetization Templates - Placeholder Consistency', () => {
       expect(content).not.toMatch(/whsec_[a-zA-Z0-9]{32,}/)
     })
   })
+
+  it('uses fixed same-origin routes for browser upgrade links', () => {
+    const landingPage = readFileSync(
+      join(monetizationDir, 'marketing/landing-page.html'),
+      'utf8'
+    )
+    const dashboard = readFileSync(
+      join(monetizationDir, 'billing/dashboard.html'),
+      'utf8'
+    )
+
+    for (const content of [landingPage, dashboard]) {
+      expect(content).not.toContain('{{UPGRADE_URL}}')
+      expect(content).not.toContain('{{ENTERPRISE_UPGRADE_URL}}')
+      expect(content).toContain('/upgrade')
+      expect(content).toContain('/enterprise')
+    }
+  })
 })
 
 describe('Monetization Templates - Configuration', () => {


### PR DESCRIPTION
## Root cause

The browser templates placed generated URL placeholders directly into navigation sinks. A malformed configured domain could therefore create an unsafe URI.

## Change

Use fixed same-origin `/upgrade` and `/enterprise` routes for browser navigation. Keep absolute generated URLs only in non-browser output where they are needed. Add a regression contract for both browser templates.

## Evidence

- Focused monetization tests: 21/21 passed
- Prettier check passed
- Existing local security scan completed
- Exact CI Semgrep image is not available locally because Docker is not installed; the PR security job is the exact authoritative check.